### PR TITLE
Fix Zone OnLeaveContainer for infinite bags

### DIFF
--- a/Zone.ttslua
+++ b/Zone.ttslua
@@ -358,7 +358,7 @@ local function onObjectLeaveContainer(container, object)
     local objectPosition = object.getPosition()
     local containerPosition = container.getPosition()
 
-    if #container.getObjects() == 0
+    if container.tag ~= "Infinite" and #container.getObjects() == 0
         and objectPosition.y <= containerPosition.y
         and objectPosition.x == containerPosition.x
         and objectPosition.z == containerPosition.z


### PR DESCRIPTION
I noticed the Zones don't like it when an object leaves an infinite bag. Infinite bags seem to have a getObjects() method (so you can't check if it's nil), but calling the method just throws the error "Attempting to call getObjects() on an object that does not support getObjects()"