### PR TITLE
added check for whether objectOrGuidOrSavedState is actually userdata object

### DIFF
--- a/Instance.ttslua
+++ b/Instance.ttslua
@@ -395,7 +395,8 @@ setmetatable(Instance, {
             object = container
             zone = containerInstance and (--[[---@not nil]] containerInstance).getZone()
         else
-            Logger.assert(objectOrGuidOrSavedState, 'Instance cannot be instantiated without an associated object')
+			Logger.assert(type(objectOrGuidOrSavedState) == "userdata" and (--[[---@type tts__Object]] objectOrGuidOrSavedState).guid, 'Instance cannot be instantiated without an associated object')
+
 
             local instanceObject = --[[---@type tts__Object]] objectOrGuidOrSavedState
             object = instanceObject


### PR DESCRIPTION
Right now the constructor can be called with a single argument and a nil, but just assumes the first argument is an object. This makes it error earlier. Not sure if this is the best way to check if a variable is a tts__object though